### PR TITLE
6.6.0 update

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "apispec" %}
 {% set version = "6.6.0" %}
-{% set sha256 = "c0846f8eaa5119c46b2ecfe9bc24ed19dba8845f8655d00b51ddd296a10ea4cb" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,11 +12,12 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - pip
     - wheel
     - setuptools
@@ -45,7 +46,7 @@ about:
   description: |
     A pluggable API specification generator. Currently supports the OpenAPI
     specification (f.k.a. Swagger 2.0).
-  doc_url: http://apispec.readthedocs.io/
+  doc_url: https://apispec.readthedocs.io/
   dev_url: https://github.com/marshmallow-code/apispec
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,32 @@
 {% set name = "apispec" %}
-{% set version = "4.7.1" %}
-{% set sha256 = "79029486d36a0d7f3c659dbf6ae50a91fbed0c22dcd5376f592e076c130bc7f9" %}
+{% set version = "6.6.0" %}
+{% set sha256 = "c0846f8eaa5119c46b2ecfe9bc24ed19dba8845f8655d00b51ddd296a10ea4cb" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: c0846f8eaa5119c46b2ecfe9bc24ed19dba8845f8655d00b51ddd296a10ea4cb
+
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.8
     - pip
     - wheel
     - setuptools
+    - flit-core <4
+
   run:
-    - python >=3.6
+    - python 
     - pyyaml >=3.10
+    - packaging >=21.3
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,14 @@ requirements:
   host:
     - python
     - pip
-    - wheel
-    - setuptools
     - flit-core <4
 
   run:
     - python 
     - pyyaml >=3.10
     - packaging >=21.3
+  run_constrained:
+    - marshmallow >=3.18.0
 
 test:
   imports:


### PR DESCRIPTION
apispec 6.6.0

**Destination channel:** defaults

### Links

- [PKG-3410](https://anaconda.atlassian.net/browse/PKG-3410) 
- [Upstream repository](https://github.com/marshmallow-code/apispec)
- [Upstream changelog/diff](https://github.com/marshmallow-code/apispec/releases/tag/6.6.0)

### Explanation of changes:

- update stale / old recipe 
- add `flit-core <4`


[PKG-3410]: https://anaconda.atlassian.net/browse/PKG-3410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ